### PR TITLE
Make Context generic over AsRef<[u8] + AsMut<[u8]>

### DIFF
--- a/examples/usage.rs
+++ b/examples/usage.rs
@@ -24,7 +24,7 @@ fn main() {
 
     // Low-level API
     let mut context = argon2::Context {
-        out:        &mut hash2,
+        out:        &mut hash2[..],
         pwd:        Some(&mut pwd),
         salt:       Some(&mut salt),
         secret:     None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ pub fn type2string(variant: Variant, uppercase: bool) -> &'static str {
 }
 
 /// Function that performs memory-hard hashing with certain degree of parallelism.
-pub fn ctx<C: TryInto<sys::Argon2_Context, Error = self::Error>>(context: C, variant: Variant) -> Result<(), Error> {
+pub fn ctx<'a, C: TryInto<sys::Argon2_Context<'a>, Error = self::Error>>(context: C, variant: Variant) -> Result<(), Error> {
     unsafe {
         Error::check_code(sys::argon2_ctx(&mut context.try_into()?, variant.to_c()) as _)
     }
@@ -35,7 +35,7 @@ pub fn ctx<C: TryInto<sys::Argon2_Context, Error = self::Error>>(context: C, var
 
 /// Argon2d: Version of Argon2 that picks memory blocks depending on the password and salt. Only
 /// for side-channel-free environment!!
-pub fn d_ctx<C: TryInto<sys::Argon2_Context, Error = self::Error>>(context: C) -> Result<(), Error> {
+pub fn d_ctx<'a, C: TryInto<sys::Argon2_Context<'a>, Error = self::Error>>(context: C) -> Result<(), Error> {
     unsafe {
         Error::check_code(sys::argon2d_ctx(&mut context.try_into()?))
     }
@@ -44,7 +44,7 @@ pub fn d_ctx<C: TryInto<sys::Argon2_Context, Error = self::Error>>(context: C) -
 /// Argon2i: Version of Argon2 that picks memory blocks
 /// independent on the password and salt. Good for side-channels,
 /// but worse with respect to tradeoff attacks if only one pass is used.
-pub fn i_ctx<C: TryInto<sys::Argon2_Context, Error = self::Error>>(context: C) -> Result<(), Error> {
+pub fn i_ctx<'a, C: TryInto<sys::Argon2_Context<'a>, Error = self::Error>>(context: C) -> Result<(), Error> {
     unsafe {
         Error::check_code(sys::argon2i_ctx(&mut context.try_into()?))
     }
@@ -54,7 +54,7 @@ pub fn i_ctx<C: TryInto<sys::Argon2_Context, Error = self::Error>>(context: C) -
 /// password-independent, the rest are password-dependent (on the password and
 /// salt). OK against side channels (they reduce to 1/2-pass Argon2i), and
 /// better with respect to tradeoff attacks (similar to Argon2d).
-pub fn id_ctx<C: TryInto<sys::Argon2_Context, Error = self::Error>>(context: C) -> Result<(), Error> {
+pub fn id_ctx<'a, C: TryInto<sys::Argon2_Context<'a>, Error = self::Error>>(context: C) -> Result<(), Error> {
     unsafe {
         Error::check_code(sys::argon2id_ctx(&mut context.try_into()?))
     }
@@ -400,7 +400,7 @@ pub fn verify(encoded: &CStr, pwd: Option<&[u8]>, variant: Variant) -> Result<()
 /// - `context`: The current Argon2 context.
 /// - `hash`: The password hash to verify. The length of the hash must match the length of the out
 /// parameter in context.
-pub fn d_verify_ctx<C: TryInto<sys::Argon2_Context, Error = self::Error>>(context: C, hash: &[u8]) -> Result<(), Error> {
+pub fn d_verify_ctx<'a, C: TryInto<sys::Argon2_Context<'a>, Error = self::Error>>(context: C, hash: &[u8]) -> Result<(), Error> {
 
     let mut argon_context = context.try_into()?;
     if hash.len() as u32 != argon_context.outlen {
@@ -424,7 +424,7 @@ pub fn d_verify_ctx<C: TryInto<sys::Argon2_Context, Error = self::Error>>(contex
 /// - `context`: The current Argon2 context.
 /// - `hash`: The password hash to verify. The length of the hash must match the length of the out
 /// parameter in context.
-pub fn i_verify_ctx<C: TryInto<sys::Argon2_Context, Error = self::Error>>(context: C, hash: &[u8]) -> Result<(), Error> {
+pub fn i_verify_ctx<'a, C: TryInto<sys::Argon2_Context<'a>, Error = self::Error>>(context: C, hash: &[u8]) -> Result<(), Error> {
 
     let mut argon_context = context.try_into()?;
     if hash.len() as u32 != argon_context.outlen {
@@ -448,7 +448,7 @@ pub fn i_verify_ctx<C: TryInto<sys::Argon2_Context, Error = self::Error>>(contex
 /// - `context`: The current Argon2 context.
 /// - `hash`: The password hash to verify. The length of the hash must match the length of the out
 /// parameter in context.
-pub fn id_verify_ctx<C: TryInto<sys::Argon2_Context, Error = self::Error>>(context: C, hash: &[u8]) -> Result<(), Error> {
+pub fn id_verify_ctx<'a, C: TryInto<sys::Argon2_Context<'a>, Error = self::Error>>(context: C, hash: &[u8]) -> Result<(), Error> {
 
     let mut argon_context = context.try_into()?;
     if hash.len() as u32 != argon_context.outlen {
@@ -472,7 +472,7 @@ pub fn id_verify_ctx<C: TryInto<sys::Argon2_Context, Error = self::Error>>(conte
 /// - `context`: The current Argon2 context.
 /// - `hash`: The password hash to verify. The length of the hash must match the length of the out
 /// parameter in context.
-pub fn verify_ctx<C: TryInto<sys::Argon2_Context, Error = self::Error>>(context: C, hash: &[u8], variant: Variant) -> Result<(), Error> {
+pub fn verify_ctx<'a, C: TryInto<sys::Argon2_Context<'a>, Error = self::Error>>(context: C, hash: &[u8], variant: Variant) -> Result<(), Error> {
 
     let mut argon_context = context.try_into()?;
     if hash.len() as u32 != argon_context.outlen {

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -2,7 +2,7 @@ use std::os::raw::c_int;
 use std::os::raw::c_void;
 use std::os::raw::c_char;
 
-pub type argon2_context = Argon2_Context;
+pub type argon2_context<'a> = Argon2_Context<'a>;
 pub type argon2_type = Argon2_type;
 
 pub type allocate_fptr = Option<unsafe extern "C" fn(memory: *mut *mut u8, bytes_to_allocate: usize) -> c_int>;
@@ -13,7 +13,7 @@ pub type Argon2_type        = c_int;
 pub type Argon2_version     = c_int;
 
 #[repr(C)]
-pub struct Argon2_Context {
+pub struct Argon2_Context<'a> {
     pub out:        *mut u8,
     pub outlen:     u32,
     pub pwd:        *mut u8,
@@ -32,6 +32,7 @@ pub struct Argon2_Context {
     pub allocate_cbk:   allocate_fptr,
     pub free_cbk:       deallocate_fptr,
     pub flags:      u32,
+    pub phantom:    std::marker::PhantomData<&'a ()>,
 }
 
 pub const Argon2_ErrorCodes_ARGON2_OK: Argon2_ErrorCodes = 0;

--- a/src/types.rs
+++ b/src/types.rs
@@ -263,17 +263,17 @@ bitflags::bitflags! {
 }
 
 /// Structure to hold Argon2 inputs.
-pub struct Context<'o, 'p, 'sa, 'se, 'ad> {
+pub struct Context<'a> {
     /// Output array.
-    pub out:    &'o mut [u8],
+    pub out:    &'a mut [u8],
     /// Password array.
-    pub pwd:    Option<&'p mut [u8]>,
+    pub pwd:    Option<&'a mut [u8]>,
     /// Salt array.
-    pub salt:   Option<&'sa mut [u8]>,
+    pub salt:   Option<&'a mut [u8]>,
     /// Secret array.
-    pub secret: Option<&'se mut [u8]>,
+    pub secret: Option<&'a mut [u8]>,
     /// Associated data array.
-    pub ad:     Option<&'ad mut [u8]>,
+    pub ad:     Option<&'a mut [u8]>,
 
     /// Number of passes.
     pub t_cost: u32,
@@ -291,7 +291,7 @@ pub struct Context<'o, 'p, 'sa, 'se, 'ad> {
     pub flags: Flags,
 }
 
-impl<'o, 'p, 'sa, 'se, 'ad> Context<'o, 'p, 'sa, 'se, 'ad> {
+impl Context<'_> {
     /// Minimum number of lanes (degree of parallelism).
     pub const MIN_LANES: u32 = 1;
     /// Maximum number of lanes (degree of parallelism).
@@ -389,7 +389,7 @@ pub struct OwnedContext {
 }
 
 impl OwnedContext {
-    pub fn borrowed<'a>(&'a mut self) -> Context<'a, 'a, 'a, 'a, 'a> {
+    pub fn borrowed<'a>(&'a mut self) -> Context<'a> {
         Context {
             out: &mut self.out,
             pwd: self.pwd.as_mut().map(|v| &mut v[0..]),
@@ -429,10 +429,10 @@ impl OwnedContext {
     }
 }
 
-impl<'o, 'p, 'sa, 'se, 'ad> std::convert::TryFrom<&mut Context<'o, 'p, 'sa, 'se, 'ad>> for sys::Argon2_Context {
+_mpl<'a> std::convert::TryFrom<&mut Context<'a>> for sys::Argon2_Context {
     type Error = self::Error;
 
-    fn try_from(context: &mut Context<'o, 'p, 'sa, 'se, 'ad>) -> Result<Self, Self::Error> {
+    fn try_from(context: &mut Context<'a>) -> Result<Self, Self::Error> {
         context.try_to_c()
     }
 }


### PR DESCRIPTION
The last change "Add an `std::marker::PhantomData` to `Argon2_Context`" is not necessarily dependent on the other two commits and could be extracted separately if you do not like to generalize `Context` this way.
I haven't put it on a separate branch since it necessitates a different implementation on the original `Context` and `OwnedContext`, creating unnecessary work assuming you approve this PR.